### PR TITLE
this plugin should now support normal mode definition of words

### DIFF
--- a/lua/nvim-dictionary.lua
+++ b/lua/nvim-dictionary.lua
@@ -32,8 +32,9 @@ function M.get_word()
 		local err
 
     if vim_mode == "n" then
-        print('not implement yet')
-        return nil
+        -- print('not implement yet')
+        -- return nil
+	local word = vim.fn.expand("<cword>")
     elseif vim_mode == "v" then
         local start_position = vim.api.nvim_eval('getpos(\"v\")')
         local end_position = vim.api.nvim_eval('getpos(\".\")')


### PR DESCRIPTION
```lua
vim.api.nvim_set_keymap("v", "<leader>sk", "<Cmd>lua require('nvim-dictionary').get_dictionary()<CR>")
vim.api.nvim_set_keymap("n", "<leader>sk", "<Cmd>lua require('nvim-dictionary').get_dictionary()<CR>")
```

Your code can further be refactored to make to the functionality of the plugin mode agnostic